### PR TITLE
SYS-1410: updating config role to new name

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -44,7 +44,7 @@ resource "aws_iam_role" "awsconfig" {
 
 resource "aws_iam_role_policy_attachment" "awsconfig_managed_policy" {
   role       = aws_iam_role.awsconfig.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
 }
 
 resource "aws_iam_role_policy_attachment" "awsconfig_local_policy" {


### PR DESCRIPTION
Message from AWS:

Hello,
AWS Config will be deprecating the managed policy AWSConfigRole on July 5, 2022, in order to scope down permissions. This policy is replaced with the policy AWS_ConfigRole. 
The AWSConfigRole managed policy will continue working for all currently attached users, groups, and roles. However, after July 5, 2022, the AWSConfigRole managed policy cannot be attached to any new users, groups, or roles. The policy will also not be updated to include permissions for newly supported resource types and new managed rules. As a user of AWSConfigRole, please update the policy attached to your AWS Config role to AWS_ConfigRole. 
To update the policy, please navigate to the IAM Role you use for Config on the IAM console [1], attach the policy AWS_ConfigRole to the role and remove the policy AWSConfigRole from the role.